### PR TITLE
Enable manual trigger for S3 deployment workflow

### DIFF
--- a/.github/workflows/deploy-app-s3.yaml
+++ b/.github/workflows/deploy-app-s3.yaml
@@ -1,5 +1,6 @@
 name: deploy-app-on-s3
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     types: [closed]


### PR DESCRIPTION
## Summary
Added support for manual workflow dispatch to the S3 deployment workflow, allowing the deployment to be triggered manually in addition to the existing automatic trigger on closed pull requests.

## Key Changes
- Added `workflow_dispatch:` trigger to the deploy-app-on-s3 workflow
- This enables manual execution of the deployment workflow from the GitHub Actions UI without requiring a pull request event

## Implementation Details
The workflow now supports two trigger mechanisms:
1. **Automatic**: Triggered when a pull request is closed against the main branch (existing behavior)
2. **Manual**: Can be manually dispatched from the GitHub Actions workflow interface (new capability)

This change improves deployment flexibility by allowing developers to manually run the deployment workflow when needed, without waiting for or creating a pull request.

https://claude.ai/code/session_0167YEE537TTqFWpubdGoyHr